### PR TITLE
fix: expose SPECIES_ID for UniProt annotations (fixes #229, mouse)

### DIFF
--- a/analysis/2.configure_sbs_params.ipynb
+++ b/analysis/2.configure_sbs_params.ipynb
@@ -818,6 +818,7 @@
     "DF_DESIGN_FP = None\n",
     "DF_BARCODE_LIBRARY_FP = \"config/barcode_library.tsv\"\n",
     "UNIPROT_DATA_FP = \"config/uniprot_data.tsv\"\n",
+    "SPECIES_ID = \"9606\"  # NCBI taxonomy ID for UniProt annotations: human=9606, mouse=10090, rat=10116, fly=7227, worm=6239\n",
     "GENE_SYMBOL_COL = None\n",
     "GENE_ID_COL = None\n",
     "\n",
@@ -850,7 +851,7 @@
    "outputs": [],
    "source": [
     "# Get uniprot data and save it temporarily\n",
-    "uniprot_data = get_uniprot_data()\n",
+    "uniprot_data = get_uniprot_data(species_id=SPECIES_ID)\n",
     "uniprot_data.to_csv(UNIPROT_DATA_FP, sep=\"\\t\", index=False)\n",
     "uniprot_data = pd.read_csv(UNIPROT_DATA_FP, sep=\"\\t\")\n",
     "\n",


### PR DESCRIPTION
## Fixes #229 — UniProt annotations for non-human (mouse) screens

`2.configure_sbs_params` called `get_uniprot_data()` with no argument, hardwiring the annotation download to **human** (taxon 9606). So `uniprot_entry` never populated for mouse (or any non-human) screens — the reported bug.

**Fix:** add a `SPECIES_ID` parameter (default `"9606"`) and pass it through, fetching fresh for the chosen organism (human=9606, mouse=10090, rat=10116, …). The lib function already supported `species_id`; the notebook just never exposed it.

Also bumps the `brieflow` submodule to the companion PR (https://github.com/cheeseman-lab/brieflow/pull/231) for the download robustness (User-Agent header + optional cache).

Clean 2-line notebook diff; nbformat validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
