### PR TITLE
cluster: pass SPECIES_ID to benchmark generation for non-human screens (#238)

### DIFF
--- a/analysis/10.configure_cluster_params.ipynb
+++ b/analysis/10.configure_cluster_params.ipynb
@@ -134,7 +134,9 @@
     "UNIPROT_DATA_FP = \"config/benchmark_clusters/uniprot_data.tsv\"\n",
     "STRING_PAIR_BENCHMARK_FP = \"config/benchmark_clusters/string_pair_benchmark.tsv\"\n",
     "CORUM_GROUP_BENCHMARK_FP = \"config/benchmark_clusters/corum_group_benchmark.tsv\"\n",
-    "KEGG_GROUP_BENCHMARK_FP = \"config/benchmark_clusters/kegg_group_benchmark.tsv\""
+    "KEGG_GROUP_BENCHMARK_FP = \"config/benchmark_clusters/kegg_group_benchmark.tsv\"\n",
+    "\n",
+    "SPECIES_ID = \"9606\"  # NCBI taxonomy ID for cluster benchmarks: human=9606, mouse=10090, rat=10116"
    ]
   },
   {
@@ -145,24 +147,24 @@
    "source": [
     "Path(STRING_PAIR_BENCHMARK_FP).parent.mkdir(parents=True, exist_ok=True)\n",
     "\n",
-    "uniprot_data = get_uniprot_data()\n",
+    "uniprot_data = get_uniprot_data(species_id=SPECIES_ID)\n",
     "uniprot_data.to_csv(UNIPROT_DATA_FP, sep=\"\\t\", index=False)\n",
     "uniprot_data = pd.read_csv(UNIPROT_DATA_FP, sep=\"\\t\")\n",
     "display(uniprot_data)\n",
     "\n",
     "string_pair_benchmark = generate_string_pair_benchmark(\n",
-    "    aggregated_data, uniprot_data, \"gene_symbol_0\"\n",
+    "    aggregated_data, uniprot_data, \"gene_symbol_0\", species_id=SPECIES_ID\n",
     ")\n",
     "string_pair_benchmark.to_csv(STRING_PAIR_BENCHMARK_FP, sep=\"\\t\", index=False)\n",
     "string_pair_benchmark = pd.read_csv(STRING_PAIR_BENCHMARK_FP, sep=\"\\t\")\n",
     "display(string_pair_benchmark)\n",
     "\n",
-    "corum_group_benchmark = generate_corum_group_benchmark()\n",
+    "corum_group_benchmark = generate_corum_group_benchmark(species_id=SPECIES_ID)\n",
     "corum_group_benchmark.to_csv(CORUM_GROUP_BENCHMARK_FP, sep=\"\\t\", index=False)\n",
     "corum_group_benchmark = pd.read_csv(CORUM_GROUP_BENCHMARK_FP, sep=\"\\t\")\n",
     "display(corum_group_benchmark)\n",
     "\n",
-    "kegg_group_benchmark = generate_msigdb_group_benchmark()\n",
+    "kegg_group_benchmark = generate_msigdb_group_benchmark(species_id=SPECIES_ID)\n",
     "kegg_group_benchmark.to_csv(KEGG_GROUP_BENCHMARK_FP, sep=\"\\t\", index=False)\n",
     "kegg_group_benchmark = pd.read_csv(KEGG_GROUP_BENCHMARK_FP, sep=\"\\t\")\n",
     "display(kegg_group_benchmark)"

--- a/analysis/10.configure_cluster_params.ipynb
+++ b/analysis/10.configure_cluster_params.ipynb
@@ -119,10 +119,13 @@
     "- `STRING_PAIR_BENCHMARK_FP`: Path to save and access STRING pair benchmark.\n",
     "- `CORUM_GROUP_BENCHMARK_FP`: Path to save and access CORUM group benchmark.\n",
     "- `KEGG_GROUP_BENCHMARK_FP`: Path to save and access KEGG group benchmark.\n",
+    "- `SPECIES_ID`: NCBI taxonomy ID of the screen organism (`\"9606\"` human, `\"10090\"` mouse, `\"10116\"` rat). Sets which organism the STRING/CORUM/pathway benchmarks below are pulled for.\n",
     "\n",
     "**Note**: We use the following benchmark schemas:\n",
     "- Pair Bechmark: `gene_name` column for gene matching with a cluster gene (or does not exist in cluster genes); `pair` column with a pair ID. Used to benchmark known pair relationships in generated cluster.\n",
-    "- Group Bechmark: `gene_name` column for gene matching with a cluster gene (or does not exist in cluster genes); `group` column with a group ID. Used to benchmark known group relationships in generated cluster, where a group represents genes involved in a pathway, protein complex, etc."
+    "- Group Bechmark: `gene_name` column for gene matching with a cluster gene (or does not exist in cluster genes); `group` column with a group ID. Used to benchmark known group relationships in generated cluster, where a group represents genes involved in a pathway, protein complex, etc.\n",
+    "\n",
+    "The generation cell below is just a convenience: it *pulls* pair/group benchmarks for `SPECIES_ID` from public databases. The pipeline itself only reads whatever TSV each `*_FP` points at, so these tables can just as easily be built by hand — assemble your own `gene_name`/`pair` or `gene_name`/`group` TSV (for an organism or curated gene set we do not auto-generate), point the matching `*_FP` at it, and skip the generation cell."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Notebook 10 (`analysis/10.configure_cluster_params.ipynb`) generated the four cluster benchmarks (UniProt, STRING, CORUM, KEGG) with **no species argument**, so they silently defaulted to human — the root cause of #238 for mouse/rat screens.

- Adds `SPECIES_ID` (default `"9606"`) alongside the benchmark file-path params.
- Threads it into all four generators: `get_uniprot_data`, `generate_string_pair_benchmark`, `generate_corum_group_benchmark`, `generate_msigdb_group_benchmark`.

A mouse screen now sets `SPECIES_ID = "10090"` and gets native mouse UniProt/STRING/CORUM plus the native mouse Reactome pathway benchmark.

## Depends on

- brieflow **main** #240 (species support in `scrape_benchmarks.py`). UniProt/STRING were already species-aware; CORUM/MSigDB support lands in #240.
- ⏳ **Submodule bump pending:** once #240 merges, this branch's `brieflow` pointer must be bumped to the merged SHA before this PR is merged.
