### PR TITLE
cluster(marimo): pass SPECIES_ID to benchmark generation for non-human screens (#238)

### DIFF
--- a/analysis/10_cluster.py
+++ b/analysis/10_cluster.py
@@ -170,10 +170,13 @@ def _(mo):
     - `STRING_PAIR_BENCHMARK_FP`: Path to save and access STRING pair benchmark.
     - `CORUM_GROUP_BENCHMARK_FP`: Path to save and access CORUM group benchmark.
     - `KEGG_GROUP_BENCHMARK_FP`: Path to save and access KEGG group benchmark.
+    - `SPECIES_ID`: NCBI taxonomy ID of the screen organism (`"9606"` human, `"10090"` mouse, `"10116"` rat). Sets which organism the STRING/CORUM/pathway benchmarks below are pulled for.
 
     **Note**: We use the following benchmark schemas:
     - Pair Bechmark: `gene_name` column for gene matching with a cluster gene (or does not exist in cluster genes); `pair` column with a pair ID. Used to benchmark known pair relationships in generated cluster.
     - Group Bechmark: `gene_name` column for gene matching with a cluster gene (or does not exist in cluster genes); `group` column with a group ID. Used to benchmark known group relationships in generated cluster, where a group represents genes involved in a pathway, protein complex, etc.
+
+    The generation cell below is just a convenience: it *pulls* pair/group benchmarks for `SPECIES_ID` from public databases. The pipeline itself only reads whatever TSV each `*_FP` points at, so these tables can just as easily be built by hand — assemble your own `gene_name`/`pair` or `gene_name`/`group` TSV (for an organism or curated gene set we do not auto-generate), point the matching `*_FP` at it, and skip the generation cell.
     """)
     return
 

--- a/analysis/10_cluster.py
+++ b/analysis/10_cluster.py
@@ -184,9 +184,11 @@ def _():
     STRING_PAIR_BENCHMARK_FP = "config/benchmark_clusters/string_pair_benchmark.tsv"
     CORUM_GROUP_BENCHMARK_FP = "config/benchmark_clusters/corum_group_benchmark.tsv"
     KEGG_GROUP_BENCHMARK_FP = "config/benchmark_clusters/kegg_group_benchmark.tsv"
+    SPECIES_ID = "9606"  # NCBI taxonomy ID for cluster benchmarks: human=9606, mouse=10090, rat=10116
     return (
         CORUM_GROUP_BENCHMARK_FP,
         KEGG_GROUP_BENCHMARK_FP,
+        SPECIES_ID,
         STRING_PAIR_BENCHMARK_FP,
         UNIPROT_DATA_FP,
     )
@@ -197,6 +199,7 @@ def _(
     CORUM_GROUP_BENCHMARK_FP,
     KEGG_GROUP_BENCHMARK_FP,
     Path,
+    SPECIES_ID,
     STRING_PAIR_BENCHMARK_FP,
     UNIPROT_DATA_FP,
     aggregated_data,
@@ -209,24 +212,24 @@ def _(
 ):
     Path(STRING_PAIR_BENCHMARK_FP).parent.mkdir(parents=True, exist_ok=True)
 
-    uniprot_data = get_uniprot_data()
+    uniprot_data = get_uniprot_data(species_id=SPECIES_ID)
     uniprot_data.to_csv(UNIPROT_DATA_FP, sep="\t", index=False)
     uniprot_data = pd.read_csv(UNIPROT_DATA_FP, sep="\t")
     mo.ui.table(uniprot_data)
 
     string_pair_benchmark = generate_string_pair_benchmark(
-        aggregated_data, uniprot_data, "gene_symbol_0"
+        aggregated_data, uniprot_data, "gene_symbol_0", species_id=SPECIES_ID
     )
     string_pair_benchmark.to_csv(STRING_PAIR_BENCHMARK_FP, sep="\t", index=False)
     string_pair_benchmark = pd.read_csv(STRING_PAIR_BENCHMARK_FP, sep="\t")
     mo.ui.table(string_pair_benchmark)
 
-    corum_group_benchmark = generate_corum_group_benchmark()
+    corum_group_benchmark = generate_corum_group_benchmark(species_id=SPECIES_ID)
     corum_group_benchmark.to_csv(CORUM_GROUP_BENCHMARK_FP, sep="\t", index=False)
     corum_group_benchmark = pd.read_csv(CORUM_GROUP_BENCHMARK_FP, sep="\t")
     mo.ui.table(corum_group_benchmark)
 
-    kegg_group_benchmark = generate_msigdb_group_benchmark()
+    kegg_group_benchmark = generate_msigdb_group_benchmark(species_id=SPECIES_ID)
     kegg_group_benchmark.to_csv(KEGG_GROUP_BENCHMARK_FP, sep="\t", index=False)
     kegg_group_benchmark = pd.read_csv(KEGG_GROUP_BENCHMARK_FP, sep="\t")
     mo.ui.table(kegg_group_benchmark)


### PR DESCRIPTION
## Summary

marimo-line hand-port of the analysis-main notebook 10 change (#79). Root cause of #238: the cluster notebook generated all four benchmarks with no species, defaulting to human.

- Adds `SPECIES_ID` (default `"9606"`) in the benchmark file-path cell.
- Threads it through the reactive DAG: returned by its defining cell, added to the consuming cell's parameters.
- Passes it to `get_uniprot_data`, `generate_string_pair_benchmark`, `generate_corum_group_benchmark`, `generate_msigdb_group_benchmark`.

Verified: `py_compile` clean, reactive-graph AST check passes (SPECIES_ID defined+returned by exactly one cell, present in every consumer's params), and no new `ruff` findings vs `origin/marimo` (the pre-existing 4 are marimo-generated formatting, untouched here).

## Depends on

- brieflow **zarr3** #241 (species support in `scrape_benchmarks.py`).
- ⏳ **Submodule bump pending:** once #241 merges, bump this branch's `brieflow` pointer to the merged zarr3 SHA before merging.
