### PR TITLE
marimo: cluster SPECIES_ID marker-wrap + flow.sh --only-plate (plugin resync support)

### DIFF
--- a/analysis/10_cluster.py
+++ b/analysis/10_cluster.py
@@ -187,7 +187,9 @@ def _():
     STRING_PAIR_BENCHMARK_FP = "config/benchmark_clusters/string_pair_benchmark.tsv"
     CORUM_GROUP_BENCHMARK_FP = "config/benchmark_clusters/corum_group_benchmark.tsv"
     KEGG_GROUP_BENCHMARK_FP = "config/benchmark_clusters/kegg_group_benchmark.tsv"
-    SPECIES_ID = "9606"  # NCBI taxonomy ID for cluster benchmarks: human=9606, mouse=10090, rat=10116
+    # === OPERATOR PARAMETERS ===
+    SPECIES_ID = "9606"  # NCBI taxid: 9606 human, 10090 mouse, 10116 rat
+    # === END OPERATOR PARAMETERS ===
     return (
         CORUM_GROUP_BENCHMARK_FP,
         KEGG_GROUP_BENCHMARK_FP,

--- a/analysis/flow.sh
+++ b/analysis/flow.sh
@@ -138,7 +138,13 @@ fi
 # Parse arguments
 # ---------------------------------------------------------------------------
 show_help() {
-    head -35 "$0" | tail -31
+    # Marker-based (not a fixed line-count slice): prints from the first to the
+    # last "# ===...===" separator line, so header edits never desync this from
+    # the actual comment block above.
+    local first last
+    first=$(grep -n '^# =\{10,\}$' "$0" | head -1 | cut -d: -f1)
+    last=$(grep -n '^# =\{10,\}$' "$0" | tail -1 | cut -d: -f1)
+    sed -n "${first},${last}p" "$0"
     exit 0
 }
 

--- a/analysis/flow.sh
+++ b/analysis/flow.sh
@@ -14,6 +14,8 @@
 #   --dry-run, -n           Show what would run without executing
 #   --sequential-plates     Process plates one at a time (auto-detects count)
 #   --plates N              Override plate count for sequential processing
+#   --only-plate N          Run only plate N, no looping (mutually exclusive
+#                           with --sequential-plates / --plates)
 #   --unlock                Force unlock before running
 #   --cores N               Number of cores for local backend (default: all)
 #   --profile               Enable profiling mode: keep all slurm logs, generate
@@ -81,7 +83,9 @@ PLATE_SEQUENTIAL_MODULES="preprocess sbs phenotype"
 BACKEND="local"
 DRY_RUN=false
 SEQUENTIAL_PLATES=true
+SEQUENTIAL_PLATES_EXPLICIT=false
 PLATE_COUNT=""
+ONLY_PLATE=""
 FORCE_UNLOCK=false
 CORES="all"
 # --jobs (max concurrent jobs): an explicit --jobs wins; otherwise resolved from
@@ -145,9 +149,11 @@ while [[ $# -gt 0 ]]; do
         --dry-run|-n)
             DRY_RUN=true; shift ;;
         --sequential-plates)
-            SEQUENTIAL_PLATES=true; shift ;;
+            SEQUENTIAL_PLATES=true; SEQUENTIAL_PLATES_EXPLICIT=true; shift ;;
         --plates)
-            SEQUENTIAL_PLATES=true; PLATE_COUNT="$2"; shift 2 ;;
+            SEQUENTIAL_PLATES=true; SEQUENTIAL_PLATES_EXPLICIT=true; PLATE_COUNT="$2"; shift 2 ;;
+        --only-plate)
+            ONLY_PLATE="$2"; shift 2 ;;
         --unlock)
             FORCE_UNLOCK=true; shift ;;
         --cores)
@@ -180,6 +186,14 @@ while [[ $# -gt 0 ]]; do
             MODULES+=("$1"); shift ;;
     esac
 done
+
+# --only-plate scopes a run to exactly one plate (no loop); it reuses the same
+# plate_filter config key --sequential-plates/--plates use per iteration, so
+# the two modes are mutually exclusive.
+if [[ -n "$ONLY_PLATE" ]] && [[ "$SEQUENTIAL_PLATES_EXPLICIT" == true ]]; then
+    echo "ERROR: --only-plate cannot be combined with --sequential-plates or --plates. Pick one plate-scoping mode."
+    exit 1
+fi
 
 # Resolve --jobs after parsing: an explicit --jobs wins; otherwise derive from
 # CORES (nproc when CORES=all). Keeps backend selection seamless — flow.sh emits
@@ -409,7 +423,31 @@ run_snakemake_module() {
         use_plates=true
     fi
 
-    if [[ "$use_plates" == true ]]; then
+    # --only-plate: scope to exactly one plate via the same plate_filter config
+    # key the sequential loop below uses per-iteration, but without looping.
+    local use_only_plate=false
+    if [[ -n "$ONLY_PLATE" ]] && [[ " $PLATE_SEQUENTIAL_MODULES " == *" $module "* ]]; then
+        use_only_plate=true
+    fi
+
+    if [[ "$use_only_plate" == true ]]; then
+        echo "Single plate processing: plate ${ONLY_PLATE}"
+        echo ""
+
+        local cmd
+        cmd=$(build_snakemake_cmd "$target" "$ONLY_PLATE")
+
+        # Add groups for slurm
+        if [[ "$BACKEND" == "slurm" ]]; then
+            local groups
+            groups=$(get_groups_flag "$module")
+            if [[ -n "$groups" ]]; then
+                cmd+=" ${groups}"
+            fi
+        fi
+
+        eval "$cmd"
+    elif [[ "$use_plates" == true ]]; then
         # Determine plate count
         local num_plates="${PLATE_COUNT}"
         if [[ -z "$num_plates" ]]; then

--- a/analysis/screen.yaml
+++ b/analysis/screen.yaml
@@ -12,7 +12,7 @@ collection:
 # =========================================================================
 experiment:
   screen_title: null                              # short slug; matches conda env brieflow_<id>
-  organism_ontology_term_id: "NCBITaxon:9606"     # default = human
+  organism_ontology_term_id: "NCBITaxon:9606"     # NCBI taxid — drives SPECIES_ID (UniProt + CORUM/MSigDB/STRING benchmarks). human 9606 · mouse 10090 · rat 10116
   organism: "Homo sapiens"
   tissue_ontology_term_id: null                   # e.g. CVCL_0030 for HeLa
   tissue: null                                    # e.g. "HeLa"
@@ -67,7 +67,13 @@ library:
 iss:
   cycles: null
   objective: null                                 # e.g. "10X 0.45 NA"
-  chemistry: "four color"
+  chemistry: "four color"                         # "four color" | "combinatorial" — combinatorial requires the combinatorial: block below
+  # combinatorial:                                # COMBINATORIAL CHEMISTRY ONLY — omit entirely for four-color G/T/A/C imaging
+  #   code:                                       # map each base to its ON dye-channels (names must match iss.channels below)
+  #     A: ["Red"]                                #   BASES + EXTRA_CHANNELS are derived from this + iss.channels
+  #     C: ["Green"]
+  #     G: ["Red", "Green"]
+  #     T: []                                     #   empty list = no dye channel ON for this base
   channels:                                       # one entry per imaging channel
     - { name: "DAPI", laser_wavelength_nm: 408, exposure_time_ms: null }
     - { name: "G",    laser_wavelength_nm: null, exposure_time_ms: null }


### PR DESCRIPTION
## Summary

Two small upstream changes the brieflow-auto plugin's branch-drift resync depends on. Targets `marimo` (not `main`) to match its current feature-branch status. Both were reviewed as part of the plugin resync work.

### 1. Wrap cluster `SPECIES_ID` in an OPERATOR PARAMETERS block (`10_cluster.py`)
`SPECIES_ID` sat outside any marker block, so the plugin's `patch_marker_block_value` could not set it — a non-human screen would silently benchmark against human CORUM/KEGG/STRING. Wrapping it makes it patchable (value + downstream uses unchanged). The plugin's shared `organism → SPECIES_ID` resolver drives it.

### 2. Add `--only-plate N` to `flow.sh`
`flow.sh` had `--plates N` (count) and `--sequential-plates` (all, one-by-one) but no single-plate selector, so autopilot's branch-and-converge SBS emission (`flow.sh sbs --only-plate N`) hit `Unknown option: exit 1`. Adds `--only-plate N` reusing the same `plate_filter` config key the sequential path uses; guards against combining it with `--plates`/`--sequential-plates`. Also makes `show_help()` marker-based (was a fixed line-count slice that the new usage line would have truncated).

## Commits
- `cluster(marimo): wrap SPECIES_ID in OPERATOR PARAMETERS block for plugin patching`
- `feat(flow.sh): add --only-plate N single-plate selector for branch-and-converge SBS`
- `fix(flow.sh): make show_help marker-based, not a fixed line-count slice`

## Test plan
- `bash -n analysis/flow.sh` clean; `bash flow.sh --help` shows the full header incl. `--only-plate`; `--only-plate 1` scopes to `plate_filter=1` without `Unknown option`; both-flags guard fires.
- Notebook parses; `scan_marker_blocks` sees the new cluster block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
