### PR TITLE
fix(notebooks): split TEST_WELL through canonical split_well (Phenix rNNcNN support)

### DIFF
--- a/analysis/2_sbs.py
+++ b/analysis/2_sbs.py
@@ -71,7 +71,7 @@ def _():
         image_segmentation_annotations,
         convert_tuples_to_lists,
     )
-    from lib.shared.file_utils import get_filename, get_hcs_nested_path
+    from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
     from lib.sbs.align_cycles import align_cycles, visualize_sbs_alignment
     from lib.shared.log_filter import log_filter
     from lib.sbs.compute_standard_deviation import compute_standard_deviation
@@ -337,8 +337,8 @@ def _(
             / get_hcs_nested_path(
                 {
                     "plate": TEST_PLATE,
-                    "row": TEST_WELL[0],
-                    "col": TEST_WELL[1:],
+                    "row": split_well(TEST_WELL)[0],
+                    "col": split_well(TEST_WELL)[1],
                     "tile": TEST_TILE,
                     "cycle": "{cycle}",
                 },
@@ -713,7 +713,7 @@ def _(
         )
 
         # Load and combine IC fields (HCS-nested zarr layout: <plate>/<row>/<col>/<cycle>/ic_field.zarr)
-        _row, _col = TEST_WELL[0], TEST_WELL[1:]
+        _row, _col = split_well(TEST_WELL)
         ic_field_dapi = read_image(
             PREPROCESS_FP
             / "ic_fields"
@@ -742,7 +742,7 @@ def _(
     else:
         # Same cycle - use single cycle for both image data and IC field
         aligned_image_data_segmentation_cycle = aligned[CYTO_CYCLE_INDEX]
-        _row, _col = TEST_WELL[0], TEST_WELL[1:]
+        _row, _col = split_well(TEST_WELL)
         ic_field = read_image(
             PREPROCESS_FP
             / "ic_fields"

--- a/analysis/3_phenotype.py
+++ b/analysis/3_phenotype.py
@@ -68,7 +68,7 @@ def _():
         image_segmentation_annotations,
         convert_tuples_to_lists,
     )
-    from lib.shared.file_utils import get_filename, get_hcs_nested_path
+    from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
     from lib.shared.illumination_correction import apply_ic_field
     from lib.phenotype.align_channels import align_phenotype_channels, visualize_phenotype_alignment
     from lib.shared.align import apply_custom_offsets
@@ -163,7 +163,7 @@ def _(
     IMAGE_FORMAT = config['all'].get('image_format', 'tiff')
     # HCS-nested zarr layout: preprocess/phenotype/<plate>/<row>/<col>/...
     # IC field: preprocess/ic_fields/phenotype/<plate>/<row>/<col>/ic_field.zarr/zarr.json
-    _row, _col = TEST_WELL[0], TEST_WELL[1:]
+    _row, _col = split_well(TEST_WELL)
     if IMAGE_FORMAT == 'zarr':
         phenotype_test_image_path = str(PREPROCESS_FP / 'phenotype' / get_hcs_nested_path({'plate': TEST_PLATE, 'row': _row, 'col': _col, 'tile': TEST_TILE}, 'image'))
     else:

--- a/analysis/5_merge.py
+++ b/analysis/5_merge.py
@@ -50,7 +50,7 @@ def _():
     import yaml
     import pandas as pd
 
-    from lib.shared.file_utils import get_filename, get_hcs_nested_path
+    from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
     from lib.shared.configuration_utils import CONFIG_FILE_HEADER, convert_tuples_to_lists
     from lib.merge.merge_utils import (
         plot_combined_tile_grid,
@@ -248,7 +248,7 @@ def _(
     # load phenotype and SBS metadata dfs (HCS-nested zarr layout: metadata + info parquets at
     # preprocess/metadata/{phenotype,sbs}/<plate>/<row>/<col>/combined_metadata.parquet and
     # {phenotype,sbs}/parquets/<plate>/<row>/<col>/{phenotype_info,sbs_info}.parquet)
-    _row, _col = TEST_WELL[0], TEST_WELL[1:]
+    _row, _col = split_well(TEST_WELL)
     ph_test_metadata_fp = ROOT_FP / 'preprocess' / 'metadata' / 'phenotype' / str(TEST_PLATE) / _row / _col / 'combined_metadata.parquet'
     ph_test_metadata = pd.read_parquet(ph_test_metadata_fp)
     if PH_METADATA_CHANNEL is not None:
@@ -465,7 +465,7 @@ def _(
     initial_alignment,
     pd,
 ):
-    _row2, _col2 = TEST_WELL[0], TEST_WELL[1:]
+    _row2, _col2 = split_well(TEST_WELL)
     _phenotype_info_fp = ROOT_FP / 'phenotype' / 'parquets' / str(TEST_PLATE) / _row2 / _col2 / 'phenotype_info.parquet'
     phenotype_info_1 = pd.read_parquet(_phenotype_info_fp)
     phenotype_info_hash = hash_cell_locations(phenotype_info_1)


### PR DESCRIPTION
## Problem

The test-tile path builders in `2_sbs.py`, `3_phenotype.py`, and `5_merge.py` split the well id with `TEST_WELL[0], TEST_WELL[1:]`. That's correct for alpha wells (`A1` → `A`/`1`) but wrong for Opera Phenix `rNNcNN` naming (`r03c05` → `r`/`03c05`), so the HCS-nested `metadata` / `ic_fields` / `parquets` paths 404 when configuring a Phenix screen's notebooks.

## Fix

Route all six sites through `lib.shared.file_utils.split_well`, which handles both conventions (alpha + Phenix). `split_well` was added to the brieflow library in cheeseman-lab/brieflow#249 (merged to `zarr3`), so this notebook change is paired with a submodule bump to that commit.

Sites (6): `2_sbs.py` test-tile dict (row/col) + two IC-field loads; `3_phenotype.py` test-tile paths; `5_merge.py` phenotype-metadata + phenotype-info paths.

No parameter values changed — only the split call. Notebooks parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)