### PR TITLE
fix(marimo): split_well for HCS paths + repair 5_merge cell decorators

### DIFF
--- a/analysis/2_sbs.py
+++ b/analysis/2_sbs.py
@@ -71,7 +71,7 @@ def _():
         image_segmentation_annotations,
         convert_tuples_to_lists,
     )
-    from lib.shared.file_utils import get_filename, get_hcs_nested_path
+    from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
     from lib.sbs.align_cycles import align_cycles, visualize_sbs_alignment
     from lib.shared.log_filter import log_filter
     from lib.sbs.compute_standard_deviation import compute_standard_deviation
@@ -337,8 +337,8 @@ def _(
             / get_hcs_nested_path(
                 {
                     "plate": TEST_PLATE,
-                    "row": TEST_WELL[0],
-                    "col": TEST_WELL[1:],
+                    "row": split_well(TEST_WELL)[0],
+                    "col": split_well(TEST_WELL)[1],
                     "tile": TEST_TILE,
                     "cycle": "{cycle}",
                 },
@@ -713,7 +713,7 @@ def _(
         )
 
         # Load and combine IC fields (HCS-nested zarr layout: <plate>/<row>/<col>/<cycle>/ic_field.zarr)
-        _row, _col = TEST_WELL[0], TEST_WELL[1:]
+        _row, _col = split_well(TEST_WELL)
         ic_field_dapi = read_image(
             PREPROCESS_FP
             / "ic_fields"
@@ -742,7 +742,7 @@ def _(
     else:
         # Same cycle - use single cycle for both image data and IC field
         aligned_image_data_segmentation_cycle = aligned[CYTO_CYCLE_INDEX]
-        _row, _col = TEST_WELL[0], TEST_WELL[1:]
+        _row, _col = split_well(TEST_WELL)
         ic_field = read_image(
             PREPROCESS_FP
             / "ic_fields"

--- a/analysis/3_phenotype.py
+++ b/analysis/3_phenotype.py
@@ -68,7 +68,7 @@ def _():
         image_segmentation_annotations,
         convert_tuples_to_lists,
     )
-    from lib.shared.file_utils import get_filename, get_hcs_nested_path
+    from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
     from lib.shared.illumination_correction import apply_ic_field
     from lib.phenotype.align_channels import align_phenotype_channels, visualize_phenotype_alignment
     from lib.shared.align import apply_custom_offsets
@@ -163,7 +163,7 @@ def _(
     IMAGE_FORMAT = config['all'].get('image_format', 'tiff')
     # HCS-nested zarr layout: preprocess/phenotype/<plate>/<row>/<col>/...
     # IC field: preprocess/ic_fields/phenotype/<plate>/<row>/<col>/ic_field.zarr/zarr.json
-    _row, _col = TEST_WELL[0], TEST_WELL[1:]
+    _row, _col = split_well(TEST_WELL)
     if IMAGE_FORMAT == 'zarr':
         phenotype_test_image_path = str(PREPROCESS_FP / 'phenotype' / get_hcs_nested_path({'plate': TEST_PLATE, 'row': _row, 'col': _col, 'tile': TEST_TILE}, 'image'))
     else:

--- a/analysis/5_merge.py
+++ b/analysis/5_merge.py
@@ -50,7 +50,7 @@ def _():
     import yaml
     import pandas as pd
 
-    from lib.shared.file_utils import get_filename, get_hcs_nested_path
+    from lib.shared.file_utils import get_filename, get_hcs_nested_path, split_well
     from lib.shared.configuration_utils import CONFIG_FILE_HEADER, convert_tuples_to_lists
     from lib.merge.merge_utils import (
         plot_combined_tile_grid,
@@ -248,7 +248,7 @@ def _(
     # load phenotype and SBS metadata dfs (HCS-nested zarr layout: metadata + info parquets at
     # preprocess/metadata/{phenotype,sbs}/<plate>/<row>/<col>/combined_metadata.parquet and
     # {phenotype,sbs}/parquets/<plate>/<row>/<col>/{phenotype_info,sbs_info}.parquet)
-    _row, _col = TEST_WELL[0], TEST_WELL[1:]
+    _row, _col = split_well(TEST_WELL)
     ph_test_metadata_fp = ROOT_FP / 'preprocess' / 'metadata' / 'phenotype' / str(TEST_PLATE) / _row / _col / 'combined_metadata.parquet'
     ph_test_metadata = pd.read_parquet(ph_test_metadata_fp)
     if PH_METADATA_CHANNEL is not None:
@@ -357,7 +357,6 @@ def _(mo):
 
 
 @app.cell
-@app.cell
 def _():
     def drop_none(**kwargs):
         """Keep only the keyword args that were actually set (drop None)."""
@@ -400,6 +399,7 @@ def _():
     )
 
 
+@app.cell
 def _(
     SEED_OPTIMIZE,
     SEED_TOPK,
@@ -465,7 +465,7 @@ def _(
     initial_alignment,
     pd,
 ):
-    _row2, _col2 = TEST_WELL[0], TEST_WELL[1:]
+    _row2, _col2 = split_well(TEST_WELL)
     _phenotype_info_fp = ROOT_FP / 'phenotype' / 'parquets' / str(TEST_PLATE) / _row2 / _col2 / 'phenotype_info.parquet'
     phenotype_info_1 = pd.read_parquet(_phenotype_info_fp)
     phenotype_info_hash = hash_cell_locations(phenotype_info_1)


### PR DESCRIPTION
Both issues blocked the zargun screen (Opera Phenix, `r02c05`-style well ids) and are reproducible on any Phenix screen.

## 1. Naive well split breaks HCS-nested paths

`TEST_WELL[0], TEST_WELL[1:]` assumes alphanumeric wells, so `"r02c05"` splits as `("r", "02c05")` instead of `("r02", "c05")` and every HCS-nested path 404s. `lib.shared.file_utils.split_well` already handles both conventions via `WELL_ROWCOL_PATTERNS` and raises on an unrecognised one rather than mis-splitting — this just uses it.

All 7 sites, which are exactly the notebooks that call `get_hcs_nested_path`:

| file | sites |
|---|---|
| `2_sbs.py` | 4 (nested-path dict, 2 IC-field loads) |
| `3_phenotype.py` | 1 |
| `5_merge.py` | 2 |

`0_preprocess.py`, `8_aggregate.py` and `10_cluster.py` need no change — aggregate and cluster read flat `P-1_W-<well>__*` merge outputs, not nested paths.

## 2. Displaced `@app.cell` in 5_merge.py

`7eb6d216` moved one decorator, producing two faults that surface one after the other:

- **stacked at line 359** — marimo applies the second decorator to the `Cell` the first returned, `inspect.getsourcelines` gets a `Cell` instead of a function, and the module dies at import:
  ```
  TypeError: module, class, method, function, traceback, frame, or code object was expected, got Cell
  ```
- **missing at line 403** — that cell was never registered, so `candidate_pairs` was never defined and its consumer failed:
  ```
  NameError: name 'candidate_pairs' is not defined
  ```

Net zero lines: one decorator removed, one restored.

## Verification

Every notebook registers its DAG with all references resolved (before: `5_merge.py` raised at import):

```
0_preprocess.py    OK  cells= 31  unresolved=none
2_sbs.py           OK  cells= 44  unresolved=none
3_phenotype.py     OK  cells= 25  unresolved=none
5_merge.py         OK  cells= 41  unresolved=none
8_aggregate.py     OK  cells= 44  unresolved=none
10_cluster.py      OK  cells= 26  unresolved=none
```

End-to-end: sbs, phenotype and merge all completed on zargun with these fixes. Merge QC passed — `ph_recovery_rate` 0.852, `sbs_recovery_rate` 0.851, `single_gene_rate` 0.526 across 20 wells / 246,314 cells.

Scoped to the fixes only — no operator-parameter values or marimo quote-style churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JQtNBvewaEmdvYnC4k7Dm